### PR TITLE
GoogleAuthenticatorQRGenerator - getOtpAuthURL method overload

### DIFF
--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticatorQRGenerator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticatorQRGenerator.java
@@ -147,9 +147,37 @@ public final class GoogleAuthenticatorQRGenerator {
                                        String accountName,
                                        GoogleAuthenticatorKey credentials) {
 
+        return getOtpAuthURL(issuer, accountName, credentials.getKey());
+    }
+
+    /**
+     * Returns the URL of a Google Chart API call to generate a QR barcode to
+     * be loaded into the Google Authenticator application.  The user scans this
+     * bar code with the application on their smart phones or enters the
+     * secret manually.
+     * <p/>
+     * The current implementation supports the following features:
+     * <ul>
+     * <li>Label, made up of an optional issuer and an account name.</li>
+     * <li>Secret parameter.</li>
+     * <li>Issuer parameter.</li>
+     * </ul>
+     *
+     * @param issuer      The issuer name. This parameter cannot contain the colon
+     *                    (:) character. This parameter can be null.
+     * @param accountName The account name. This parameter shall not be null.
+     * @param key         The generated key from credentials. This parameter shall not be null.
+     * @return the Google Chart API call URL to generate a QR code containing
+     * the provided information.
+     * @see <a href="https://code.google.com/p/google-authenticator/wiki/KeyUriFormat">Google Authenticator - KeyUriFormat</a>
+     */
+    public static String getOtpAuthURL(String issuer,
+                                       String accountName,
+                                       String key) {
+
         return String.format(
                 TOTP_URI_FORMAT,
-                getOtpAuthTotpURL(issuer, accountName, credentials));
+                getOtpAuthTotpURL(issuer, accountName, key));
     }
 
     /**
@@ -166,18 +194,18 @@ public final class GoogleAuthenticatorQRGenerator {
      * @param issuer      The issuer name. This parameter cannot contain the colon
      *                    (:) character. This parameter can be null.
      * @param accountName The account name. This parameter shall not be null.
-     * @param credentials The generated credentials.  This parameter shall not be null.
+     * @param key         The generated key from credentials. This parameter shall not be null.
      * @return the Google Chart API call URL to generate a QR code containing
      * the provided information.
      * @see <a href="https://code.google.com/p/google-authenticator/wiki/KeyUriFormat">Google Authenticator - KeyUriFormat</a>
      */
     public static String getOtpAuthTotpURL(String issuer,
                                            String accountName,
-                                           GoogleAuthenticatorKey credentials) {
+                                           String key) {
         return internalURLEncode(
                 String.format(
                         OTP_AUTH_TOTP_URI_BASE,
                         formatLabel(issuer, accountName),
-                        credentials.getKey()) + formatIssuerParameter(issuer));
+                        key) + formatIssuerParameter(issuer));
     }
 }


### PR DESCRIPTION
GoogleAuthenticatorQRGenerator - getOtpAuthURL method with String secretKey param instead if GoogleAuthenticatorKey param.
It is necessary in case QR code generation, when GoogleAuthenticatorKey already is not exists (GoogleAuthenticatorKey has package visibility for constructor, so couldn't be easily recreated).
