### PR TITLE
Made the GoogleAuthenticatorKey constructor public

### DIFF
--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticatorKey.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticatorKey.java
@@ -80,7 +80,7 @@ public final class GoogleAuthenticatorKey {
      * @param code         the verification code at time = 0 (the UNIX epoch).
      * @param scratchCodes the list of scratch codes.
      */
-    /* package */ GoogleAuthenticatorKey(
+    public GoogleAuthenticatorKey(
             String secretKey, int code,
             List<Integer> scratchCodes) {
         key = secretKey;


### PR DESCRIPTION
I would like to store the GoogleAuthenticatorKey in my MongoDB database.
Sinds the class is not serializable I have to store it as separate values.

To be able to generate a QR code link after retrieving the values from the database I have to create a new instance of the GoogleAuthenticatorKey and fill it with the values.
Since there are no setters available and the contructor is package-private I'm unable to fill it.

With this pull request I'd like to make the constructor public so we are able to repopulate a GoogleAuthenticatorKey class with the values from the database.
