### PR TITLE
Fix getTotpPasswordOfUser call to use helper

### DIFF
--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -514,7 +514,7 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
 
     public int getTotpPasswordOfUser(String userName)
     {
-        return getTotpPassword(userName, new Date().getTime());
+        return getTotpPasswordOfUser(userName, new Date().getTime());
     }
 
     public int getTotpPasswordOfUser(String userName, long time)


### PR DESCRIPTION
The getTotpPasswordOfUser method with just the userName parameter does not appropriately call getTotpPasswordOfUser(String userName, long time).
Instead, it calls the getTotpPassword helper with userName as the key.