### PR TITLE
Make the number of secret bits configurable

### DIFF
--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -96,13 +96,6 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     private static final Logger LOGGER = Logger.getLogger(GoogleAuthenticator.class.getName());
 
     /**
-     * The number of bits of a secret key in binary form. Since the Base32
-     * encoding with 8 bit characters introduces an 160% overhead, we just need
-     * 80 bits (10 bytes) to generate a 16 bytes Base32-encoded secret key.
-     */
-    private static final int SECRET_BITS = 80;
-
-    /**
      * Number of digits of a scratch code represented as a decimal integer.
      */
     private static final int SCRATCH_CODE_LENGTH = 8;
@@ -340,13 +333,14 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     public GoogleAuthenticatorKey createCredentials()
     {
         // Allocating a buffer sufficiently large to hold the bytes required by
-        // the secret key and the scratch codes.
-        byte[] buffer = new byte[SECRET_BITS / 8];
+        // the secret key.
+        int bufferSize = config.getSecretBits() / 8;
+        byte[] buffer = new byte[bufferSize];
 
         secureRandom.nextBytes(buffer);
 
         // Extracting the bytes making up the secret key.
-        byte[] secretKey = Arrays.copyOf(buffer, SECRET_BITS / 8);
+        byte[] secretKey = Arrays.copyOf(buffer, bufferSize);
         String generatedKey = calculateSecretKey(secretKey);
 
         // Generating the verification code at time = 0.

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticatorConfig.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticatorConfig.java
@@ -39,6 +39,7 @@ public class GoogleAuthenticatorConfig
     private int codeDigits = 6;
     private int numberOfScratchCodes = 5;
     private int keyModulus = (int) Math.pow(10, codeDigits);
+    private int secretBits = 80;
     private KeyRepresentation keyRepresentation = KeyRepresentation.BASE32;
     private HmacHashFunction hmacHashFunction = HmacHashFunction.HmacSHA1;
 
@@ -111,6 +112,17 @@ public class GoogleAuthenticatorConfig
     public int getWindowSize()
     {
         return windowSize;
+    }
+
+    /**
+     * Returns the number of bits of the secret keys to generate.  The length should always be a
+     * multiple of 8.  The default value is 80 bits for historical reasons and backwards
+     * compatibility.  RFC 4226 §4 requires 128 bits and recommends 160 bits.
+     *
+     * @return the secret size in bits.
+     */
+    public int getSecretBits() {
+        return secretBits;
     }
 
     /**
@@ -192,6 +204,21 @@ public class GoogleAuthenticatorConfig
             }
 
             config.windowSize = windowSize;
+            return this;
+        }
+
+        public GoogleAuthenticatorConfigBuilder setSecretBits(int secretBits)
+        {
+            if (secretBits <= 0)
+            {
+                throw new IllegalArgumentException("Secret bits must be positive.");
+            }
+            if (secretBits % 8 != 0)
+            {
+                throw new IllegalArgumentException("Secret bits must be a multiple of 8.");
+            }
+
+            config.secretBits = secretBits;
             return this;
         }
 


### PR DESCRIPTION
The hard-coded value used to be 80 bits, whereas RFC 4226 §4 R6 requires 128 bits and recommends 160 bits.

The Google Authenticator app is capable of handling these longer secrets too.