### PR TITLE
Code42/allow null secure random number gen

### DIFF
--- a/doc/totp.texi
+++ b/doc/totp.texi
@@ -271,7 +271,8 @@ available on Oracle Java runtime environments and they were not tested on other
 implementations where they are likely to be missing.
 
 Users can configure the library to use an alternate provider and algorithm by
-providing their names as values of the following system properties:
+providing their names as values of the following system properties or they can
+specify this in the @code{GoogleAuthenticator} constructor:
 
 @table @command
 @item com.warrenstrange.googleauth.rng.algorithm
@@ -594,9 +595,8 @@ values specified in @acronym{RFC 6238}.  Specifically, this class uses:
 @item
 The @acronym{HMAC-SHA-1} algorithm is used, as specified by @acronym{RFC} 4226.
 @acronym{RFC} 6238 specifies that implementors @emph{may} also use
-@acronym{HMAC-SHA-256} and @acronym{HMAC-SHA-512} but, although the code already
-supports them, currently there is no way to override the usage of
-@acronym{HMAC-SHA-1}.
+@acronym{HMAC-SHA-256} and @acronym{HMAC-SHA-512} and can be used by specifying them
+in the constructor of @code{GoogleAuthenticator}.
 
 @item
 A time-step size of 30 seconds is used, as recommended in by @acronym{RFC} 6238.

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -239,15 +239,6 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
                 DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER);
     }
 
-    private String getRandomNumberAlgorithmProvider(final String algorithmProvider) {
-        return System.getProperty(
-                RNG_ALGORITHM_PROVIDER,
-                algorithmProvider
-        );
-    }
-
-
-
     /**
      * Calculates the verification code of the provided key at the specified
      * instant of time using the algorithm specified in RFC 6238.

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -133,7 +133,6 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
      */
     private static final String DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER = "SUN";
 
-
     /**
      * The configuration used by the current instance.
      */
@@ -227,13 +226,6 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
         return System.getProperty(
                 RNG_ALGORITHM,
                 DEFAULT_RANDOM_NUMBER_ALGORITHM);
-    }
-
-    private String getRandomNumberAlgorithm(final String algorithm) {
-        return System.getProperty(
-                RNG_ALGORITHM,
-                algorithm
-        );
     }
 
     /**

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -133,6 +133,10 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
      */
     private static final String DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER = "SUN";
 
+    private String randomNumberAlgorithm;
+
+    private String randomNumberAlgorithmProvider;
+
     /**
      * The configuration used by the current instance.
      */
@@ -156,6 +160,9 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     public GoogleAuthenticator()
     {
         config = new GoogleAuthenticatorConfig();
+
+        this.randomNumberAlgorithmProvider = DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER;
+        this.randomNumberAlgorithm = DEFAULT_RANDOM_NUMBER_ALGORITHM;
     }
 
     public GoogleAuthenticator(GoogleAuthenticatorConfig config)
@@ -166,6 +173,28 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
         }
 
         this.config = config;
+
+        this.randomNumberAlgorithmProvider = DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER;
+        this.randomNumberAlgorithm = DEFAULT_RANDOM_NUMBER_ALGORITHM;
+    }
+
+    public GoogleAuthenticator(final String randomNumberAlgorithmProvider, final String randomNumberAlgorithm) {
+        config = new GoogleAuthenticatorConfig();
+        this.randomNumberAlgorithm = randomNumberAlgorithm;
+        this.randomNumberAlgorithmProvider = randomNumberAlgorithmProvider;
+    }
+
+    public GoogleAuthenticator(GoogleAuthenticatorConfig config, final String randomNumberAlgorithmProvider, final String randomNumberAlgorithm)
+    {
+        if (config == null)
+        {
+            throw new IllegalArgumentException("Configuration cannot be null.");
+        }
+
+        this.config = config;
+
+        this.randomNumberAlgorithm = randomNumberAlgorithm;
+        this.randomNumberAlgorithmProvider = randomNumberAlgorithmProvider;
     }
 
     /**
@@ -176,7 +205,7 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     {
         return System.getProperty(
                 RNG_ALGORITHM,
-                DEFAULT_RANDOM_NUMBER_ALGORITHM);
+                this.randomNumberAlgorithm);
     }
 
     /**
@@ -187,7 +216,7 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     {
         return System.getProperty(
                 RNG_ALGORITHM_PROVIDER,
-                DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER);
+                this.randomNumberAlgorithmProvider);
     }
 
     /**

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -177,23 +177,11 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
 
     public GoogleAuthenticator(final String randomNumberAlgorithm, final String randomNumberAlgorithmProvider)
     {
-        config = new GoogleAuthenticatorConfig();
+        this(new GoogleAuthenticatorConfig(), randomNumberAlgorithm, randomNumberAlgorithmProvider);
 
-        if (randomNumberAlgorithm == null && randomNumberAlgorithmProvider == null)
-        {
-            this.secureRandom = new ReseedingSecureRandom();
-        }
-        else if (randomNumberAlgorithm == null)
-        {
-            throw new IllegalArgumentException("RandomNumberAlgorithm must not be null. If the RandomNumberAlgorithm is null, the RandomNumberAlgorithmProvider must also be null.");
-        }
-        else if (randomNumberAlgorithmProvider == null)
-        {
-            this.secureRandom = new ReseedingSecureRandom(randomNumberAlgorithm);
-        }
     }
 
-    public GoogleAuthenticator(GoogleAuthenticatorConfig config, final String randomNumberAlgorithmProvider, final String randomNumberAlgorithm)
+    public GoogleAuthenticator(GoogleAuthenticatorConfig config, final String randomNumberAlgorithm, final String randomNumberAlgorithmProvider)
     {
         if (config == null)
         {

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -155,7 +155,6 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     {
         config = new GoogleAuthenticatorConfig();
 
-
         this.secureRandom = new ReseedingSecureRandom(
                 getRandomNumberAlgorithm(),
                 getRandomNumberAlgorithmProvider());

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -151,6 +151,9 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     private ICredentialRepository credentialRepository;
     private boolean credentialRepositorySearched;
 
+    /**
+     * The constructor that uses the default config, random number algorithm, and random number algorithm provider.
+     */
     public GoogleAuthenticator()
     {
         config = new GoogleAuthenticatorConfig();
@@ -160,6 +163,11 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
                 getRandomNumberAlgorithmProvider());
     }
 
+    /**
+     * The constructor that allows a user to specify the config and uses the default randomNumberAlgorithm and randomNumberAlgorithmProvider.
+     *
+     * @param config The configuration used by the current instance.
+     */
     public GoogleAuthenticator(GoogleAuthenticatorConfig config)
     {
         if (config == null)
@@ -175,12 +183,25 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
         );
     }
 
+    /**
+     * The constructor that allows a user the randomNumberAlgorithm, the randomNumberAlgorithmProvider, and uses the default config.
+     *
+     * @param randomNumberAlgorithm The random number algorithm to define the secure random number generator. If this is null the randomNumberAlgorithmProvider must be null.
+     * @param randomNumberAlgorithmProvider The random number algorithm provider to define the secure random number generator. This value may be null.
+     */
     public GoogleAuthenticator(final String randomNumberAlgorithm, final String randomNumberAlgorithmProvider)
     {
         this(new GoogleAuthenticatorConfig(), randomNumberAlgorithm, randomNumberAlgorithmProvider);
 
     }
 
+    /**
+     * The constructor that allows a user to specify the config, the randomNumberAlgorithm, and the randomNumberAlgorithmProvider.
+     *
+     * @param config The configuration used by the current instance.
+     * @param randomNumberAlgorithm The random number algorithm to define the secure random number generator. If this is null the randomNumberAlgorithmProvider must be null.
+     * @param randomNumberAlgorithmProvider The random number algorithm provider to define the secure random number generator. This value may be null.
+     */
     public GoogleAuthenticator(GoogleAuthenticatorConfig config, final String randomNumberAlgorithm, final String randomNumberAlgorithmProvider)
     {
         if (config == null)

--- a/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
+++ b/src/main/java/com/warrenstrange/googleauth/GoogleAuthenticator.java
@@ -133,9 +133,6 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
      */
     private static final String DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER = "SUN";
 
-    private String randomNumberAlgorithm;
-
-    private String randomNumberAlgorithmProvider;
 
     /**
      * The configuration used by the current instance.
@@ -150,9 +147,7 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
      * that it is expected to work correctly in previous versions of the Java
      * platform as well.
      */
-    private ReseedingSecureRandom secureRandom = new ReseedingSecureRandom(
-            getRandomNumberAlgorithm(),
-            getRandomNumberAlgorithmProvider());
+    private ReseedingSecureRandom secureRandom;
 
     private ICredentialRepository credentialRepository;
     private boolean credentialRepositorySearched;
@@ -161,8 +156,10 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
     {
         config = new GoogleAuthenticatorConfig();
 
-        this.randomNumberAlgorithmProvider = DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER;
-        this.randomNumberAlgorithm = DEFAULT_RANDOM_NUMBER_ALGORITHM;
+
+        this.secureRandom = new ReseedingSecureRandom(
+                getRandomNumberAlgorithm(),
+                getRandomNumberAlgorithmProvider());
     }
 
     public GoogleAuthenticator(GoogleAuthenticatorConfig config)
@@ -174,14 +171,28 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
 
         this.config = config;
 
-        this.randomNumberAlgorithmProvider = DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER;
-        this.randomNumberAlgorithm = DEFAULT_RANDOM_NUMBER_ALGORITHM;
+        this.secureRandom = new ReseedingSecureRandom(
+                getRandomNumberAlgorithm(),
+                getRandomNumberAlgorithmProvider()
+        );
     }
 
-    public GoogleAuthenticator(final String randomNumberAlgorithmProvider, final String randomNumberAlgorithm) {
+    public GoogleAuthenticator(final String randomNumberAlgorithm, final String randomNumberAlgorithmProvider)
+    {
         config = new GoogleAuthenticatorConfig();
-        this.randomNumberAlgorithm = randomNumberAlgorithm;
-        this.randomNumberAlgorithmProvider = randomNumberAlgorithmProvider;
+
+        if (randomNumberAlgorithm == null && randomNumberAlgorithmProvider == null)
+        {
+            this.secureRandom = new ReseedingSecureRandom();
+        }
+        else if (randomNumberAlgorithm == null)
+        {
+            throw new IllegalArgumentException("RandomNumberAlgorithm must not be null. If the RandomNumberAlgorithm is null, the RandomNumberAlgorithmProvider must also be null.");
+        }
+        else if (randomNumberAlgorithmProvider == null)
+        {
+            this.secureRandom = new ReseedingSecureRandom(randomNumberAlgorithm);
+        }
     }
 
     public GoogleAuthenticator(GoogleAuthenticatorConfig config, final String randomNumberAlgorithmProvider, final String randomNumberAlgorithm)
@@ -193,31 +204,57 @@ public final class GoogleAuthenticator implements IGoogleAuthenticator
 
         this.config = config;
 
-        this.randomNumberAlgorithm = randomNumberAlgorithm;
-        this.randomNumberAlgorithmProvider = randomNumberAlgorithmProvider;
+        if (randomNumberAlgorithm == null && randomNumberAlgorithmProvider == null)
+        {
+            this.secureRandom = new ReseedingSecureRandom();
+        }
+        else if (randomNumberAlgorithm == null)
+        {
+            throw new IllegalArgumentException("RandomNumberAlgorithm must not be null. If the RandomNumberAlgorithm is null, the RandomNumberAlgorithmProvider must also be null.");
+        }
+        else if (randomNumberAlgorithmProvider == null)
+        {
+            this.secureRandom = new ReseedingSecureRandom(randomNumberAlgorithm);
+        }
     }
 
     /**
-     * @return the random number generator algorithm.
+     * @return the default random number generator algorithm.
      * @since 0.5.0
      */
     private String getRandomNumberAlgorithm()
     {
         return System.getProperty(
                 RNG_ALGORITHM,
-                this.randomNumberAlgorithm);
+                DEFAULT_RANDOM_NUMBER_ALGORITHM);
+    }
+
+    private String getRandomNumberAlgorithm(final String algorithm) {
+        return System.getProperty(
+                RNG_ALGORITHM,
+                algorithm
+        );
     }
 
     /**
-     * @return the random number generator algorithm provider.
+     * @return the default random number generator algorithm provider.
      * @since 0.5.0
      */
     private String getRandomNumberAlgorithmProvider()
     {
         return System.getProperty(
                 RNG_ALGORITHM_PROVIDER,
-                this.randomNumberAlgorithmProvider);
+                DEFAULT_RANDOM_NUMBER_ALGORITHM_PROVIDER);
     }
+
+    private String getRandomNumberAlgorithmProvider(final String algorithmProvider) {
+        return System.getProperty(
+                RNG_ALGORITHM_PROVIDER,
+                algorithmProvider
+        );
+    }
+
+
 
     /**
      * Calculates the verification code of the provided key at the specified

--- a/src/main/java/com/warrenstrange/googleauth/ReseedingSecureRandom.java
+++ b/src/main/java/com/warrenstrange/googleauth/ReseedingSecureRandom.java
@@ -43,7 +43,6 @@ class ReseedingSecureRandom
     private final AtomicInteger count = new AtomicInteger(0);
     private volatile SecureRandom secureRandom;
 
-    @SuppressWarnings("UnusedDeclaration")
     ReseedingSecureRandom()
     {
         this.algorithm = null;
@@ -52,7 +51,6 @@ class ReseedingSecureRandom
         buildSecureRandom();
     }
 
-    @SuppressWarnings("UnusedDeclaration")
     ReseedingSecureRandom(String algorithm)
     {
         if (algorithm == null)

--- a/src/test/java/com/warrenstrange/googleauth/GoogleAuthTest.java
+++ b/src/test/java/com/warrenstrange/googleauth/GoogleAuthTest.java
@@ -192,6 +192,14 @@ public class GoogleAuthTest
     }
 
     @Test
+    public void createAndAuthenticateNullAlgorithm() {
+        final GoogleAuthenticator ga = new GoogleAuthenticator(null, null);
+        final GoogleAuthenticatorKey key = ga.createCredentials();
+
+        assertTrue(ga.authorize(key.getKey(), ga.getTotpPassword(key.getKey())));
+    }
+
+    @Test
     public void createCredentialsForUser()
     {
         GoogleAuthenticator googleAuthenticator = new GoogleAuthenticator();


### PR DESCRIPTION
This pull request allows the GoogleAuthenticator class to be initialized with user specified values for the secure random algorithm and secure random algorithm provider. This is necessary for us because we will not necessarily have the default algorithm and algorithm provider currently hard coded in the project.